### PR TITLE
SD-639 add support for proper timezone handling for rfc3164 timestamps. ...

### DIFF
--- a/multiparser/multiparser_test.go
+++ b/multiparser/multiparser_test.go
@@ -10,10 +10,21 @@ import (
 
 // Hooks up gocheck into the gotest runner.
 func TestMutliParser(t *testing.T) { TestingT(t) }
-type MultiParserTestSuite struct {}
+type MultiParserTestSuite struct {
+  originalLocale *time.Location
+}
 var _ = Suite(&MultiParserTestSuite{})
 
 var rfc3164ValidMsg []byte = []byte("<94>Jun 06 20:07:15 webtest-mark simlogging[17155]: This is a log.info() message")
+
+func (s *MultiParserTestSuite) SetUpTest(c *C) {
+  s.originalLocale = time.Local
+  time.Local = time.UTC
+}
+
+func (s *MultiParserTestSuite) TearDownTest(c *C) {
+  time.Local = s.originalLocale
+}
 
 func (s *MultiParserTestSuite) TestRfc3164Message(c *C) {
   parser := NewRfcParser(&rfc3164ValidMsg)

--- a/rfc3164/message_test.go
+++ b/rfc3164/message_test.go
@@ -13,9 +13,19 @@ func TestMessage(t *testing.T) { TestingT(t) }
 var sampleRfc3164Log = []byte("<94>Jun 06 20:07:15 webtest-mark simlogging[17155]: This is a log.info() message")
 
 type Rfc3164MessageTestSuite struct {
+  originalLocale *time.Location
 }
 
 var _ = Suite(&Rfc3164MessageTestSuite{})
+
+func (s *Rfc3164MessageTestSuite) SetUpTest(c *C) {
+  s.originalLocale = time.Local
+  time.Local = time.UTC
+}
+
+func (s *Rfc3164MessageTestSuite) TearDownTest(c *C) {
+  time.Local = s.originalLocale
+}
 
 func (s *Rfc3164MessageTestSuite) TestMessageFromRfc3164(c *C) {
   parser := NewParser(&sampleRfc3164Log)
@@ -31,7 +41,7 @@ func (s *Rfc3164MessageTestSuite) TestMessageFromRfc3164(c *C) {
   c.Assert("simlogging", Equals, msg.Process())
   c.Assert(message.Info, Equals, msg.Severity())
   c.Assert(message.Ftp, Equals, msg.Facility())
-  c.Assert("", Equals, msg.Pid())
+  c.Assert("17155", Equals, msg.Pid())
 }
 
 func (s *Rfc3164MessageTestSuite) TestMessageCantParseMessage(c *C) {

--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -160,8 +160,9 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
     }
 
     sub = p.buff[p.cursor : tsFmtLen+p.cursor]
-    ts, err = time.Parse(tsFmt, string(sub))
+    ts, err = time.ParseInLocation(tsFmt, string(sub), time.Local)
     if err == nil {
+      ts = ts.UTC()
       found = true
       break
     }


### PR DESCRIPTION
... RFC-3164 states that the timezone should be assumed to be the local system time.
