### PR TITLE
SD-1451 Year applied to RFC-3164 messages before converting to UTC so th...

### DIFF
--- a/rfc3164/message_test.go
+++ b/rfc3164/message_test.go
@@ -37,7 +37,7 @@ func (s *Rfc3164MessageTestSuite) TestMessageFromRfc3164(c *C) {
   c.Assert(string(sampleRfc3164Log), Equals, string(*msg.RawMessage()))
   c.Assert("webtest-mark", Equals, msg.Hostname())
   c.Assert("This is a log.info() message", Equals, msg.Message())
-  c.Assert(true, Equals, time.Unix(1402085235, 0).Equal(msg.TimeStamp()))
+  c.Assert(true, Equals, time.Unix(1433621235, 0).Equal(msg.TimeStamp()))
   c.Assert("simlogging", Equals, msg.Process())
   c.Assert(message.Info, Equals, msg.Severity())
   c.Assert(message.Ftp, Equals, msg.Facility())

--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -162,6 +162,11 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
     sub = p.buff[p.cursor : tsFmtLen+p.cursor]
     ts, err = time.ParseInLocation(tsFmt, string(sub), time.Local)
     if err == nil {
+      /* Set Year on the Timestamp before converting to UTC so that time zone and
+         DST settings (which are year dependent) can be properly assessed in the
+         conversion. */
+      fixTimestampIfNeeded(&ts)
+
       ts = ts.UTC()
       found = true
       break
@@ -179,8 +184,6 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
 
     return ts, syslogparser.ErrTimestampUnknownFormat
   }
-
-  fixTimestampIfNeeded(&ts)
 
   p.cursor += tsFmtLen
 


### PR DESCRIPTION
...at timezone/DST settings are applied appropriate to that year

(cherry picked from commit fa8238d7bc8acb42d0d80158b434b543a74fd37c)