### PR TITLE
SD-1658 Don't parse past message bounds in invalid RFC3164

### DIFF
--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -55,6 +55,10 @@ func (p *Parser) Parse() error {
   }
 
   p.cursor++
+ 
+  if p.cursor >= p.l {
+    return syslogparser.ErrEOL
+  }
 
   msg, err := p.parsemessage()
   if err != syslogparser.ErrEOL {


### PR DESCRIPTION
yolo++