### PR TITLE
SD-1581 Syslog RFC3164 allows slashes in tags (for process names)

### DIFF
--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -215,8 +215,9 @@ func (p *Parser) parseTag() (string, error) {
     if (curChar >= '0' && curChar <= '9') ||
       (curChar >= 'a' && curChar <= 'z') ||
       (curChar >= 'A' && curChar <= 'Z') ||
-      /* Allow non-compliant tags with "-" and "_" */
+      /* Allow non-compliant tags with "-", "_", "/" */
        curChar == '-' || curChar == '_' ||
+       curChar == '/'
       /* Note that the spec says to stop on *any* non-alphanumeric, but the original
          author of this lib specifically allowed '.' chars so we're retaining this
          divergance from the specification until we find a reason not to. */


### PR DESCRIPTION
It seems that nobody complies with the "only 32 characters, ABNF alphanumeric" requirement for the TAG field. We could instead scan until we hit one of ` : [`. 