### PR TITLE
ROCANA-2123 Add support for RFC3164 messages with a 4-digit year

### DIFF
--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -157,13 +157,13 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
 
   tsFmts := []string{
     "Jan 02 15:04:05 2006",
-    "Jan 02 15:04:05",
     "Jan  2 15:04:05 2006",
+    "Jan 02 15:04:05",
     "Jan  2 15:04:05",
   }
 
   found := false
-  for _, tsFmt := range tsFmts {
+  for i, tsFmt := range tsFmts {
     tsFmtLen = len(tsFmt)
 
     if p.cursor+tsFmtLen > p.l {
@@ -177,10 +177,11 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
     if p.cursor+tsFmtLen == p.l || p.buff[p.cursor + tsFmtLen] == ' ' {
       ts, err = time.ParseInLocation(tsFmt, string(sub), time.Local)
       if err == nil {
-        // Only use a pattern with a year for "reasonable" years 
-        if (ts.Year() > 0 && ts.Year() < 2000) || ts.Year() > 2100 {
-	  continue
-        }
+	// The first two patterns have a year component - check that it's "reasonable"
+	// (1999 < year < 2100).
+	if i < 2  && ! ( ts.Year() > 1999 && ts.Year() < 2100) {
+          continue
+	}
         /* Set Year on the Timestamp before converting to UTC so that time zone and
            DST settings (which are year dependent) can be properly assessed in the
            conversion. */


### PR DESCRIPTION
Handle non-compliant RFC3164 messages that have a year field. The year field must be terminated by a space. This will misparse valid messages if the host name is actually a 4-digit number.

edit: After discussion with field, we carved out an exemption for numeric host names that couldn't reasonably be mistaken for the year. We only use the year if 1999 < year < 2101
